### PR TITLE
Allow app to run someone other than the root level of the webserver

### DIFF
--- a/src/components/UniverseMap.jsx
+++ b/src/components/UniverseMap.jsx
@@ -31,7 +31,7 @@ const UniverseMap = React.memo(() => {
   useEffect(() => {
     if (!graph || !graph.edges) return;
 
-    d3.xml('/PrUn_universe_map_normalized.svg').then(data => {
+    d3.xml('PrUn_universe_map_normalized.svg').then(data => {
       const svgNode = data.documentElement;
       const container = document.getElementById('map-container');
 

--- a/src/contexts/GraphContext.js
+++ b/src/contexts/GraphContext.js
@@ -12,7 +12,7 @@ export const GraphProvider = ({ children }) => {
 
   useEffect(() => {
     console.log('Fetching graph data');
-    fetch('/graph_data.json')
+    fetch('graph_data.json')
       .then(response => response.json())
       .then(data => {
         setGraph(data);
@@ -21,7 +21,7 @@ export const GraphProvider = ({ children }) => {
         console.error('Error fetching graph data:', error);
       });
 
-    fetch('/material_data.json')
+    fetch('material_data.json')
       .then(response => response.json())
       .then(data => {
         setMaterials(data);
@@ -30,7 +30,7 @@ export const GraphProvider = ({ children }) => {
         console.error('Error fetching material data:', error);
       });
 
-    fetch('/prun_universe_data.json')
+    fetch('prun_universe_data.json')
       .then(response => response.json())
       .then(data => {
         // Group planets by SystemId
@@ -48,7 +48,7 @@ export const GraphProvider = ({ children }) => {
       });
 
     // Fetch planet data
-    fetch('/planet_data.json')
+    fetch('planet_data.json')
       .then(response => response.json())
       .then(data => {
         // Group planets by SystemId

--- a/src/hooks/useFetchGraphData.js
+++ b/src/hooks/useFetchGraphData.js
@@ -5,7 +5,7 @@ export const useFetchGraphData = () => {
 
   useEffect(() => {
     console.log('useFetchGraphData hook executed');
-    fetch('/graph_data.json')
+    fetch('graph_data.json')
       .then(response => response.json())
       .then(data => {
         console.log('Fetched Graph Data:', data);

--- a/src/utils/svgUtils.js
+++ b/src/utils/svgUtils.js
@@ -11,8 +11,8 @@ let planetData = null;
 const fetchData = async () => {
   try {
     const [universeResponse, planetResponse] = await Promise.all([
-      fetch('/prun_universe_data.json'),
-      fetch('/planet_data.json')
+      fetch('prun_universe_data.json'),
+      fetch('planet_data.json')
     ]);
     const universeJson = await universeResponse.json();
     const planetJson = await planetResponse.json();


### PR DESCRIPTION
This fix changes some absolute paths that assume certain resources are available at the root of the webserver into absolute paths. This allows the prun_universe_map to be hosted in a subdirectory, rather than only at the root level of a domain. 

The leading "/" on the fetch calls specifies the root level. Otherwise they are relative to the app. 

This is helpful because I want to run the page at:
http://oog.kortham.net/map/

In order to do that, I changed the react "homepage" property to include my "map" url. If you'd like to test this feature specifically, you may want to try that. Documentation is available here:
https://create-react-app.dev/docs/deployment/#building-for-relative-paths

If you apply this patch but don't change your homepage, the app continues to work as before. (it just also works in a sub directory).

(I love the map by the way! 😀  ) 